### PR TITLE
Allow truthmatching with proof.

### DIFF
--- a/core/FinalStateManager.cpp
+++ b/core/FinalStateManager.cpp
@@ -24,8 +24,8 @@ namespace chanser{
     fs->SetEventParticles(&_eventParts); //link to data
     fs->SetEventInfo(_data->GetEventInfo());
     if(_data->IsSim()){
-      fs->SetTruthParticles(&_data->GetTruth()); //link to truth particles
-      fs->SetHasTruth();
+       fs->SetTruthParticles(&_data->GetTruth()); //link to truth particles
+       fs->SetHasTruth();
     }
 
     //functions otherwise handled by constructor
@@ -59,6 +59,8 @@ namespace chanser{
     _finalStates.push_back(std::move(fs));//take a copy
     return kTRUE;
   }
+
+
   ///////////////////////////////////////////////////////////////
   ///Process all events in the hipo file
   void  FinalStateManager::ProcessAll(Long64_t Nmax){
@@ -92,6 +94,13 @@ namespace chanser{
   void  FinalStateManager::Init(){
     MakeBaseOutputDir();
     
+    if(_useTruthProof){
+      for(const auto& fs : _finalStates){
+	fs->SetTruthParticles(&_data->GetTruth()); //link to truth particles
+	fs->SetHasTruth();
+      }
+    }
+
     if(_data->IsLund()){ //if reading LUND events only
       for(const auto& fs:_finalStates)
 	fs->SetGenerated();

--- a/core/FinalStateManager.h
+++ b/core/FinalStateManager.h
@@ -53,6 +53,8 @@ namespace chanser{
     const TString& BaseOutDir(){return _baseOutDir;};
     void SetBaseOutDir(const TString& name){_baseOutDir=name;}
     void MakeBaseOutputDir();
+    //force using truth because of bug with proof
+    void UseTruth(bool useTruth){_useTruthProof=useTruth;};
     
   private :
       
@@ -65,6 +67,8 @@ namespace chanser{
       
       
     TString _baseOutDir;
+
+    bool _useTruthProof{false};
     
     ClassDef(chanser::FinalStateManager,2); //class EventParticles
       

--- a/core/HipoData.cpp
+++ b/core/HipoData.cpp
@@ -5,13 +5,7 @@ namespace chanser{
   ////////////////////////////////////////////////////////////////////////
   ///Initialise clas12reader from hipo filename
   Bool_t HipoData::SetFile(const TString filename){
-    _c12=nullptr;
-
-    //current hack for finding if simulated data
-    //Only works if run number from gemc ==11  !!!!
-    if(clas12::clas12reader::readQuickRunConfig(filename.Data())==11){
-      _dataType=static_cast<Short_t> (chanser::DataType::Sim);
-    }
+    _c12=nullptr;    
 
     _myC12.reset(new clas12::clas12reader(filename.Data(),{0})); //for ownership
     _c12=_myC12.get(); //for using
@@ -23,6 +17,12 @@ namespace chanser{
   ///Initialise clas12reader from hipo filename
   Bool_t HipoData::Init(){
     
+    //current hack for finding if simulated data
+    //Only works if run number from gemc ==11  !!!!
+    if(clas12::clas12reader::readQuickRunConfig(_c12->getFilename())==11){
+      _dataType=static_cast<Short_t> (chanser::DataType::Sim);
+    }
+
     _eventInfo.SetCLAS12( _c12 );
     _runInfo.SetCLAS12( _c12 );
     if( _myWriter.get()&& (_c12!=nullptr) ) _myWriter->assignReader(*_c12);

--- a/core/HipoProcessor.cpp
+++ b/core/HipoProcessor.cpp
@@ -52,7 +52,7 @@ namespace chanser{
     //give the hipor data reader to FinalStateManager
     //Data files are opened in Notify (see also HipoSelector)
     _fsm.LoadData(&_hipo);
-  
+
     //now initiliase all final states
     auto listFinalStates=(dynamic_cast<TList*>(fInput->FindObject("LISTOFFINALSTATES")));
 
@@ -63,7 +63,6 @@ namespace chanser{
       _fsm.LoadFinalState(listFinalStates->At(ifs)->GetName(),listFinalStates->At(ifs)->GetTitle(),workerName);
     }
 
-    
     //Get the output directory
     auto bDir=(dynamic_cast<TNamed*>(fInput->FindObject("FSBASEDIR")));
     _fsm.SetBaseOutDir(bDir->GetTitle());
@@ -208,6 +207,14 @@ namespace chanser{
      
       _fsm.GetEventParticles().SetMaxParticles(maxParts);
     }
+
+     /////////////////////////////////////////////////
+    ///Use truth matching
+    opt=dynamic_cast<TNamed*>(options->FindObject("HIPOPROCESSOR_TRUTHMATCH"));
+    if(opt!=nullptr){
+      _fsm.UseTruth(true);
+    }
+
     /////////////////////////////////////////////////
     /////////////////////////////////////////////////
     ///Write filtered hipo output file


### PR DESCRIPTION
Truthmatching didn't work with proof for two reasons. Firstly the SetFile function of the HipoData isn't called when using proof so _dataType was never set to Sim. This is fixed by setting _dataType to Sim in the Init() function.

Secondly because when the HipoProcessor passed the data reader to the FinalStateManger with LoadData, the data reader hasn't yet been passed a file so it doesn't know whether or not this file is simulated. This is fixed by passing an option ("HIPOPROCESSOR_TRUTHMATCH") to the HipoProcessor which then tells the FinalStateManger to use truth matching in ApplyOptions. When the FinalStateManager Init() function is called, truthmatching is set up as with the LoadData function for each final state.

This requires the line "processor.AddOption("HIPOPROCESSOR_TRUTHMATCH","0");" in the Processor.C file which is called with chanser_proof to set up the truthmatching option.