### PR TITLE
fix: rm threshold passed correctly

### DIFF
--- a/core/MaskCalorNeutronSplitOffs.h
+++ b/core/MaskCalorNeutronSplitOffs.h
@@ -21,7 +21,7 @@ namespace chanser{
   public :
     MaskCalorNeutronSplitOffs()=default;
 
-  MaskCalorNeutronSplitOffs(Float_t r0,Float_t rp,Float_t rm):_r0min{r0},_rpmin{rp},_rnmin{r0}{};
+  MaskCalorNeutronSplitOffs(Float_t r0,Float_t rp,Float_t rm):_r0min{r0},_rpmin{rp},_rnmin{rm}{};
     
     virtual ~MaskCalorNeutronSplitOffs();//=default;
     MaskCalorNeutronSplitOffs(const MaskCalorNeutronSplitOffs& other) = delete; //Copy Constructor

--- a/core/MaskCalorSplitOffs.h
+++ b/core/MaskCalorSplitOffs.h
@@ -21,7 +21,7 @@ namespace chanser{
   public :
     MaskCalorSplitOffs()=default;
 
-  MaskCalorSplitOffs(Float_t r0,Float_t rp,Float_t rm,Short_t add):_r0min{r0},_rpmin{rp},_rnmin{r0},_addSplits{add}{};
+  MaskCalorSplitOffs(Float_t r0,Float_t rp,Float_t rm,Short_t add):_r0min{r0},_rpmin{rp},_rnmin{rm},_addSplits{add}{};
     
     virtual ~MaskCalorSplitOffs();//=default;
     MaskCalorSplitOffs(const MaskCalorSplitOffs& other) = delete; //Copy Constructor


### PR DESCRIPTION
Fixes a bug in the MaskCalorSplitOffs and MaskCalorNeutronSplitOffs classes where the R0 value for neutral particles was wrongly being passed to the Rm value for negative particles.